### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 setuptools>=41.2.0
 setuptools_scm>=3.3.3
-numpy>=1.17.0
+numpy<1.24
 scipy>=1.3.1
 pandas>=1.0.3
 h5py>=2.9.0


### PR DESCRIPTION
numpy has deprecated `float` in version 1.24.

install lower version