### PR TITLE
Remove reference to deprecated np.float

### DIFF
--- a/cellex/preprocessing/anova.py
+++ b/cellex/preprocessing/anova.py
@@ -4,7 +4,7 @@ import time
 import datetime
 from scipy import stats
 
-def anova(df: pd.DataFrame, annotation: np.ndarray, threshold: np.float=0.00001, verbose: bool=False):
+def anova(df: pd.DataFrame, annotation: np.ndarray, threshold: float=0.00001, verbose: bool=False):
     """Apply ANOVA and filter data
     Applies ANOVA to identify lowly / sporadically expressed genes and remove them.
     Values of each gene (row) is split into groups according to the annotation.


### PR DESCRIPTION
In more recent versions of numpy, the `np.float` alias is deprecated ([link](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)). 

I haven't regenerated the pdocs because I wasn't sure if you had a preference for how it should be run. I can do this if helpful.